### PR TITLE
Fixed URL Patterns

### DIFF
--- a/rest_registration/api/urls.py
+++ b/rest_registration/api/urls.py
@@ -15,21 +15,21 @@ from .views import (
 
 app_name = 'rest_registration'
 urlpatterns = [
-    url('register/$', register, name='register'),
-    url('verify-registration/$', verify_registration,
+    url('^register/$', register, name='register'),
+    url('^verify-registration/$', verify_registration,
         name='verify-registration'),
 
-    url('send-reset-password-link/$', send_reset_password_link,
+    url('^send-reset-password-link/$', send_reset_password_link,
         name='send-reset-password-link'),
-    url('reset-password/$', reset_password, name='reset-password'),
+    url('^reset-password/$', reset_password, name='reset-password'),
 
-    url('login/$', login, name='login'),
-    url('logout/$', logout, name='logout'),
+    url('^login/$', login, name='login'),
+    url('^logout/$', logout, name='logout'),
 
-    url('profile/$', profile, name='profile'),
+    url('^profile/$', profile, name='profile'),
 
-    url('change-password/$', change_password, name='change-password'),
+    url('^change-password/$', change_password, name='change-password'),
 
-    url('register-email/$', register_email, name='register-email'),
-    url('verify-email/$', verify_email, name='verify-email'),
+    url('^register-email/$', register_email, name='register-email'),
+    url('^verify-email/$', verify_email, name='verify-email'),
 ]

--- a/rest_registration/api/views/login.py
+++ b/rest_registration/api/views/login.py
@@ -70,7 +70,7 @@ def logout(request):
 
     if should_authenticate_session():
         auth.logout(request)
-    elif should_retrieve_token() and request.data.get('revoke_token', None) == True:
+    elif should_retrieve_token() and request.data.get('revoke_token', None):
         request.user.auth_token.delete()
 
     return get_ok_response('Logout successful')

--- a/rest_registration/api/views/login.py
+++ b/rest_registration/api/views/login.py
@@ -68,7 +68,10 @@ def logout(request):
     if not request.user.is_authenticated:
         raise BadRequest('Not logged in')
 
-    auth.logout(request)
+    if should_authenticate_session():
+        auth.logout(request)
+    elif should_retrieve_token() and request.data.get('revoke_token', None) == True:
+        request.user.auth_token.delete()
 
     return get_ok_response('Logout successful')
 


### PR DESCRIPTION
Currently if we want to access any of the URLs it can start with any random string as long as it ends with one of the URL patterns.  

For example, `example.com/api/login` and `example.com/api/randomstringlogin` both works and gets directed to the same view.

Adding a `^` to the URL patterns fixes that.